### PR TITLE
bugfix: not hang on reading from FIFO

### DIFF
--- a/script/scan-prereqs-cpanfile
+++ b/script/scan-prereqs-cpanfile
@@ -193,6 +193,7 @@ sub load_diff_src {
 
 sub read_from_file {
     my ($fname, $length) = @_;
+    return q{} if !-f $fname;
     open my $fh, '<', $fname
         or Carp::croak("Can't open '$fname' for reading: '$!'");
     my $buf;


### PR DESCRIPTION
Current implementation skip only UNIX sockets, but there are many other special file types (FIFO, block/char devices, symlinks) which doesn't make sense to read. Probably you'll never have a perl project with block/char device files in project directory, but FIFO are very usual and used a lot, for example by service supervisors (like daemontools/runit/s6).