### PR TITLE
restore --scan-test-requires option

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,9 +5,8 @@ requires 'Module::CPANfile', '0.9020';
 requires 'Module::CoreList';
 requires 'Module::Metadata';
 requires 'Perl::PrereqScanner::Lite', '0.21';
+requires 'Test::Requires::Scanner';
 requires 'version';
-
-recommends 'Test::Requires::Scanner';
 
 on test => sub {
     requires 'Test::More', 0.98;

--- a/lib/App/scan_prereqs_cpanfile.pm
+++ b/lib/App/scan_prereqs_cpanfile.pm
@@ -6,7 +6,7 @@ our $VERSION = "1.03";
 
 use Exporter 5.57 'import';
 our @EXPORT_OK = qw(
-    debugf find_perl_files scan_inner_packages scan
+    debugf find_perl_files scan_inner_packages scan scan_test_requires
 );
 
 use version ();
@@ -20,9 +20,6 @@ use File::Basename ();
 use Module::Metadata ();
 use Perl::PrereqScanner::Lite;
 
-
-
-
 sub debugf {
     if ($ENV{SCAN_PREREQS_CPANFILE_DEBUG}) {
         require Data::Dumper;
@@ -34,8 +31,6 @@ sub debugf {
         print $txt, "\n";
     }
 }
-
-
 
 sub scan {
     my ($files, $inner_packages, $meta_prereqs, $prereq_types, $type, $optional_prereqs) = @_;

--- a/script/scan-prereqs-cpanfile
+++ b/script/scan-prereqs-cpanfile
@@ -9,7 +9,7 @@ use File::Basename ();
 use Module::CPANfile ();
 
 use App::scan_prereqs_cpanfile qw(
-    debugf find_perl_files scan_inner_packages scan
+    debugf find_perl_files scan_inner_packages scan scan_test_requires
 );
 
 my $version;
@@ -106,6 +106,7 @@ scan-prereqs-cpanfile - Scan prerequisite modules and generate CPANfile
         --diff=cpanfile       # Generate diff from cpanfile
         --ignore=extlib
         --dir=/foo/bar
+        --scan-test-requires
 
 =head1 DESCRIPTION
 
@@ -160,7 +161,7 @@ By default, phases without any prereqs are not dumped, By giving this option, cp
 
 Defaults to false.
 
-=item --scan-test-requires (EXPERIMENTAL)
+=item --scan-test-requires
 
 Scan test files and include the modules specified by L<Test::Requires> as 'develop' requires.
 


### PR DESCRIPTION
The `--scan-test-requires` option is accidentally removed on HEAD. (The latest CPAN dist was in a state before it was removed.)

So, I restore it and make it an official feature. It works well for a long time.